### PR TITLE
Support .NET Core version of dnSpy

### DIFF
--- a/dnSpy Restart as/RestartMenuCommandProvider.cs
+++ b/dnSpy Restart as/RestartMenuCommandProvider.cs
@@ -33,8 +33,7 @@ namespace dnSpy_Restart_as {
             var dnSpyLocation;
             var dnSpyFilename;
             var dnSpyFolder;
-            if (isUsingNetCore == true)
-            {
+            if (isUsingNetCore == true) {
                 /*
                  * Expect a fixed folder structure. Note that due to 0xd4d custom 
                  * patch the executable is always in the parent folder in .NET Core
@@ -46,8 +45,7 @@ namespace dnSpy_Restart_as {
                 dnSpyFilename = "dnSpy.exe";
                 dnSpyLocation = Path.Combine(dnSpyFolder, dnSpyFilename);
             }
-            else
-            {
+            else {
                 dnSpyFolder = AppDomain.CurrentDomain.BaseDirectory;
                 dnSpyFilename = $"dnSpy{(bit32 ? "-x86" : "")}.exe";
                 dnSpyLocation = Path.Combine(dnSpyFolder, dnSpyFilename);

--- a/dnSpy Restart as/RestartMenuCommandProvider.cs
+++ b/dnSpy Restart as/RestartMenuCommandProvider.cs
@@ -30,9 +30,9 @@ namespace dnSpy_Restart_as {
                 .GetCustomAttribute<TargetFrameworkAttribute>()?
                 .FrameworkName.StartsWith(".NETCoreApp");
 
-            string dnSpyLocation;
-            string dnSpyFilename;
-            string dnSpyFolder;
+            var dnSpyLocation;
+            var dnSpyFilename;
+            var dnSpyFolder;
             if (isUsingNetCore == true)
             {
                 /*
@@ -53,9 +53,7 @@ namespace dnSpy_Restart_as {
                 dnSpyLocation = Path.Combine(dnSpyFolder, dnSpyFilename);
             }
 
-            ProcessStartInfo startInfo = new ProcessStartInfo(dnSpyLocation);
-
-            if (!File.Exists(startInfo.FileName)) {
+            if (!File.Exists(dnSpyLocation)) {
                 MsgBox.Instance.Show($"Could not find '{dnSpyFilename}' in folder '{dnSpyFolder}', can not restart as {(bit32 ? "32" : "64")}bit !");
                 return;
             }
@@ -63,6 +61,7 @@ namespace dnSpy_Restart_as {
             // Close dnSpy (save all settings so dnSpy can open correctly again)
             ((ICommand)ApplicationCommands.Close).Execute(context);
 
+            var startInfo = new ProcessStartInfo(dnSpyLocation);
 
             if (asAdmin) {
                 startInfo.UseShellExecute = true;


### PR DESCRIPTION
.NET Core releases no longer shared a single folder. This is why we expect a fixed folder structure in order to make this happen at all. To make this expectation clear for users who don't know the source we simply print out the expected folder in the error message.